### PR TITLE
Minor gradle fixes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,13 @@
 apply plugin: 'java'
 apply plugin: 'maven-publish'
 apply plugin: 'checkstyle'
+apply plugin: 'findbugs'
+apply plugin: 'jacoco'
 
 group = 'com.bealetech'
-version = '2.3.1-SNAPSHOT'
+version = '2.4.0-SNAPSHOT'
 
-description = 'Metrics Statsd Support'
+description = 'Metrics StatsD Support'
 
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
@@ -19,25 +21,63 @@ task sourceJar(type: Jar) {
 }
 
 publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            from components.java
+  publications {
+    mavenJava(MavenPublication) {
+      from components.java
 
-            artifact sourceJar {
-                classifier "sources"
-            }
-        }
+      artifact sourceJar {
+        classifier "sources"
+      }
     }
+  }
 }
 
 dependencies {
-    compile group: 'com.yammer.metrics', name: 'metrics-core', version:'2.1.3'
-    compile group: 'org.slf4j', name: 'slf4j-jdk14', version:'1.7.5'
-    testCompile group: 'junit', name: 'junit-dep', version:'4.11'
-    testCompile group: 'org.mockito', name: 'mockito-all', version:'1.9.5'
+  compile (
+    ['com.yammer.metrics:metrics-core:2.1.3'],
+    ['org.slf4j:slf4j-api:1.7.5'],
+    ['com.google.code.findbugs:jsr305:2.0.1'],
+    ['com.google.code.findbugs:annotations:2.0.1'],
+  )
+  
+  testCompile (
+    ['junit:junit:4.11'],
+    ['org.mockito:mockito-all:1.9.5'],
+    ['org.slf4j:slf4j-jdk14:1.7.5'],
+  )
 }
 
+tasks.withType(Compile) { 
+  options.compilerArgs << "-Xlint:all" 
+} 
+
 checkstyle {
+  toolVersion = '5.6'
+  showViolations = false
   sourceSets = [sourceSets.main]
   configFile = file("$rootDir/config/checkstyle/checkstyle.xml")
+}
+
+findbugs {
+  toolVersion = '2.0.1'
+  ignoreFailures = true
+}
+
+jacocoTestReport {
+  reports {
+    html.enabled = true
+    csv.enabled = true
+    xml.enabled = true
+  } 
+}
+
+defaultTasks 'build'
+
+jacocoTestReport.dependsOn(test)
+build.dependsOn javadoc
+build.dependsOn jacocoTestReport
+
+
+task wrapper(type: Wrapper) {
+  gradleVersion = '1.6'
 }

--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -4,19 +4,13 @@
 <!--
     This configuration file was written by the eclipse-cs plugin configuration editor
 -->
-<!--
-    Checkstyle-Configuration: riak-crdt
-    Description: none
--->
+
 <module name="Checker">
   <property name="severity" value="warning"/>
   <module name="TreeWalker">
     <property name="tabWidth" value="4"/>
-    <module name="FileContentsHolder"/>
     <module name="JavadocStyle"/>
-    <module name="ConstantName">
-      <property name="format" value="^[A-Za-z][A-Za-z0-9]*(_[A-Z0-9]+)*$"/>
-    </module>
+    <module name="ConstantName"/>
     <module name="LocalFinalVariableName"/>
     <module name="LocalVariableName">
       <property name="format" value="^[_]?[a-z][a-zA-Z0-9]*$"/>
@@ -75,9 +69,12 @@
     </module>
     <module name="SimplifyBooleanExpression"/>
     <module name="SimplifyBooleanReturn"/>
+    <module name="FinalClass"/>
+    <module name="HideUtilityClassConstructor"/>
     <module name="InterfaceIsType"/>
     <module name="VisibilityModifier"/>
     <module name="ArrayTypeStyle"/>
+    <module name="FinalParameters"/>
     <module name="TodoComment">
       <property name="severity" value="ignore"/>
       <metadata name="net.sf.eclipsecs.core.lastEnabledSeverity" value="inherit"/>


### PR DESCRIPTION
- Changed Statsd to StatsD to conform with naming standard of project.
  - Added findbugs and jacoco plugins.
  - Made the jacoco plugin run on build.
  - Made the javadoc task run on build.
  - Explicitly specified the tool version for checkstyle and used an up-to-date checkstyle file.
  - Added default task.
  - Updated version to 2.4.0-SNAPSHOT in light of recent changes.
  - Split the slf4j dependency so that under compile it only depends on slf4j-api.
  - Test still depends on slf4j-jdk for simplicity.
  - Changed to junit:junit:4.11 from junit:junit-dep:4.11, since with 4.11
    junit-dep has been deprecated.
  - Added the findbugs annotations and JSR305 annotations.
  - Enabled Xlint:all on compile.
  - Made the wrapper version explicit.
