### PR TITLE
Metrics 3 Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,7 @@ subprojects {
       ['junit:junit:4.11'],
       ['org.mockito:mockito-all:1.9.5'],
       ['org.slf4j:slf4j-jdk14:1.7.5'],
+      ['org.easytesting:fest-assert-core:2.0M10'],
     )
   }
 

--- a/metrics3-statsd/build.gradle
+++ b/metrics3-statsd/build.gradle
@@ -1,0 +1,5 @@
+version = '3.0.0-SNAPSHOT'
+
+dependencies {
+  provided 'com.codahale.metrics:metrics-core:3.0.0'
+}

--- a/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/DatagramSocketFactory.java
+++ b/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/DatagramSocketFactory.java
@@ -1,0 +1,16 @@
+package com.bealetech.metrics.reporting;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+
+public class DatagramSocketFactory {
+  public DatagramSocket createSocket() throws SocketException {
+    return new DatagramSocket();
+  }
+
+  public DatagramPacket createPacket(byte[] bytes, int length, InetSocketAddress address) throws SocketException {
+    return new DatagramPacket(bytes, length, address);
+  }
+}

--- a/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/StatsD.java
+++ b/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/StatsD.java
@@ -1,0 +1,98 @@
+package com.bealetech.metrics.reporting;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.util.regex.Pattern;
+
+/**
+ * A client to a StatsD server.
+ */
+public class StatsD implements Closeable {
+  private static final Pattern WHITESPACE = Pattern.compile("[\\s]+");
+
+  private static final Charset UTF_8 = Charset.forName("UTF-8");
+
+  private final InetSocketAddress address;
+  private final DatagramSocketFactory socketFactory;
+
+  private DatagramSocket socket;
+  private int failures;
+
+  /**
+   * Creates a new client which connects to the given address using the default
+   * {@link DatagramSocketFactory}.
+   *
+   * @param address the address of the StatsD server
+   */
+  public StatsD(InetSocketAddress address) {
+    this(address, new DatagramSocketFactory());
+  }
+
+  /**
+   * Creates a new client which connects to the given address and socket factory.
+   *
+   * @param address the address of the Carbon server
+   * @param socketFactory the socket factory
+   */
+  public StatsD(InetSocketAddress address, DatagramSocketFactory socketFactory) {
+    this.address = address;
+    this.socketFactory = socketFactory;
+  }
+
+  /**
+   * Connects to the server.
+   *
+   * @throws IllegalStateException if the client is already connected
+   * @throws IOException if there is an error connecting
+   */
+  public void connect() throws IllegalStateException, IOException {
+    if (socket != null) {
+      throw new IllegalStateException("Already connected");
+    }
+
+    this.socket = socketFactory.createSocket();
+  }
+
+  /**
+   * Sends the given measurement to the server.
+   *
+   * @param name         the name of the metric
+   * @param value        the value of the metric
+   * @throws IOException if there was an error sending the metric
+   */
+  public void send(String name, String value) throws IOException {
+    try {
+      String formatted = String.format("%s:%s|g", sanitize(name), sanitize(value));
+      byte[] bytes = formatted.getBytes(UTF_8);
+      socket.send(socketFactory.createPacket(bytes, bytes.length, address));
+      failures = 0;
+    } catch (IOException e) {
+      failures++;
+      throw e;
+    }
+  }
+
+  /**
+   * Returns the number of failed writes to the server.
+   *
+   * @return the number of failed writes to the server
+   */
+  public int getFailures() {
+    return failures;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (socket != null) {
+      socket.close();
+    }
+    this.socket = null;
+  }
+
+  protected String sanitize(String s) {
+    return WHITESPACE.matcher(s).replaceAll("-");
+  }
+}

--- a/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/StatsDReporter.java
+++ b/metrics3-statsd/src/main/java/com/bealetech/metrics/reporting/StatsDReporter.java
@@ -1,0 +1,270 @@
+package com.bealetech.metrics.reporting;
+
+import com.codahale.metrics.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A reporter which publishes metric values to a StatsD server.
+ *
+ * @see <a href="https://github.com/etsy/statsd">StatsD</a>
+ */
+public class StatsDReporter extends ScheduledReporter {
+  /**
+   * Returns a new {@link Builder} for {@link StatsDReporter}.
+   *
+   * @param registry the registry to report
+   * @return a {@link Builder} instance for a {@link StatsDReporter}
+   */
+  public static Builder forRegistry(MetricRegistry registry) {
+    return new Builder(registry);
+  }
+
+  /**
+   * A builder for {@link StatsDReporter} instances. Defaults to not using a prefix,
+   * converting rates to events/second, converting durations to milliseconds, and not
+   * filtering metrics.
+   */
+  public static class Builder {
+    private final MetricRegistry registry;
+    private String prefix;
+    private TimeUnit rateUnit;
+    private TimeUnit durationUnit;
+    private MetricFilter filter;
+
+    private Builder(MetricRegistry registry) {
+      this.registry = registry;
+      this.prefix = null;
+      this.rateUnit = TimeUnit.SECONDS;
+      this.durationUnit = TimeUnit.MILLISECONDS;
+      this.filter = MetricFilter.ALL;
+    }
+
+    /**
+     * Prefix all metric names with the given string.
+     *
+     * @param prefix the prefix for all metric names
+     * @return {@code this}
+     */
+    public Builder prefixedWith(String prefix) {
+      this.prefix = prefix;
+      return this;
+    }
+
+    /**
+     * Convert rates to the given time unit.
+     *
+     * @param rateUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertRatesTo(TimeUnit rateUnit) {
+      this.rateUnit = rateUnit;
+      return this;
+    }
+
+    /**
+     * Convert durations to the given time unit.
+     *
+     * @param durationUnit a unit of time
+     * @return {@code this}
+     */
+    public Builder convertDurationsTo(TimeUnit durationUnit) {
+      this.durationUnit = durationUnit;
+      return this;
+    }
+
+    /**
+     * Only report metrics which match the given filter.
+     *
+     * @param filter a {@link MetricFilter}
+     * @return {@code this}
+     */
+    public Builder filter(MetricFilter filter) {
+      this.filter = filter;
+      return this;
+    }
+
+    /**
+     * Builds a {@link StatsDReporter} with the given properties, sending metrics using the
+     * given {@link StatsD} client.
+     *
+     * @param statsD a {@link StatsD} client
+     * @return a {@link StatsDReporter}
+     */
+    public StatsDReporter build(StatsD statsD) {
+      return new StatsDReporter(registry,
+        statsD,
+        prefix,
+        rateUnit,
+        durationUnit,
+        filter);
+    }
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(StatsDReporter.class);
+
+  private final StatsD statsD;
+  private final String prefix;
+
+  private StatsDReporter(MetricRegistry registry,
+                         StatsD statsD,
+                         String prefix,
+                         TimeUnit rateUnit,
+                         TimeUnit durationUnit,
+                         MetricFilter filter) {
+    super(registry, "statsd-reporter", filter, rateUnit, durationUnit);
+    this.statsD = statsD;
+    this.prefix = prefix;
+  }
+
+  @Override
+  public void report(SortedMap<String, Gauge> gauges,
+                     SortedMap<String, Counter> counters,
+                     SortedMap<String, Histogram> histograms,
+                     SortedMap<String, Meter> meters,
+                     SortedMap<String, Timer> timers) {
+
+    try {
+      statsD.connect();
+
+      for (Map.Entry<String, Gauge> entry : gauges.entrySet()) {
+        reportGauge(entry.getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<String, Counter> entry : counters.entrySet()) {
+        reportCounter(entry.getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
+        reportHistogram(entry.getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<String, Meter> entry : meters.entrySet()) {
+        reportMetered(entry.getKey(), entry.getValue());
+      }
+
+      for (Map.Entry<String, Timer> entry : timers.entrySet()) {
+        reportTimer(entry.getKey(), entry.getValue());
+      }
+    } catch (IOException e) {
+      LOGGER.warn("Unable to report to StatsD", statsD, e);
+    } finally {
+      try {
+        statsD.close();
+      } catch (IOException e) {
+        LOGGER.debug("Error disconnecting from StatsD", statsD, e);
+      }
+    }
+  }
+
+  private void reportTimer(String name, Timer timer) throws IOException {
+    final Snapshot snapshot = timer.getSnapshot();
+
+    statsD.send(prefix(name, "max"), format(convertDuration(snapshot.getMax())));
+    statsD.send(prefix(name, "mean"), format(convertDuration(snapshot.getMean())));
+    statsD.send(prefix(name, "min"), format(convertDuration(snapshot.getMin())));
+    statsD.send(prefix(name, "stddev"),
+      format(convertDuration(snapshot.getStdDev()))
+    );
+    statsD.send(prefix(name, "p50"),
+      format(convertDuration(snapshot.getMedian()))
+    );
+    statsD.send(prefix(name, "p75"),
+      format(convertDuration(snapshot.get75thPercentile()))
+    );
+    statsD.send(prefix(name, "p95"),
+      format(convertDuration(snapshot.get95thPercentile()))
+    );
+    statsD.send(prefix(name, "p98"),
+      format(convertDuration(snapshot.get98thPercentile()))
+    );
+    statsD.send(prefix(name, "p99"),
+      format(convertDuration(snapshot.get99thPercentile()))
+    );
+    statsD.send(prefix(name, "p999"),
+      format(convertDuration(snapshot.get999thPercentile()))
+    );
+
+    reportMetered(name, timer);
+  }
+
+  private void reportMetered(String name, Metered meter) throws IOException {
+    statsD.send(prefix(name, "count"), format(meter.getCount()));
+    statsD.send(prefix(name, "m1_rate"),
+      format(convertRate(meter.getOneMinuteRate()))
+    );
+    statsD.send(prefix(name, "m5_rate"),
+      format(convertRate(meter.getFiveMinuteRate()))
+    );
+    statsD.send(prefix(name, "m15_rate"),
+      format(convertRate(meter.getFifteenMinuteRate()))
+    );
+    statsD.send(prefix(name, "mean_rate"),
+      format(convertRate(meter.getMeanRate()))
+    );
+  }
+
+  private void reportHistogram(String name, Histogram histogram) throws IOException {
+    final Snapshot snapshot = histogram.getSnapshot();
+    statsD.send(prefix(name, "count"), format(histogram.getCount()));
+    statsD.send(prefix(name, "max"), format(snapshot.getMax()));
+    statsD.send(prefix(name, "mean"), format(snapshot.getMean()));
+    statsD.send(prefix(name, "min"), format(snapshot.getMin()));
+    statsD.send(prefix(name, "stddev"), format(snapshot.getStdDev()));
+    statsD.send(prefix(name, "p50"), format(snapshot.getMedian()));
+    statsD.send(prefix(name, "p75"), format(snapshot.get75thPercentile()));
+    statsD.send(prefix(name, "p95"), format(snapshot.get95thPercentile()));
+    statsD.send(prefix(name, "p98"), format(snapshot.get98thPercentile()));
+    statsD.send(prefix(name, "p99"), format(snapshot.get99thPercentile()));
+    statsD.send(prefix(name, "p999"), format(snapshot.get999thPercentile()));
+  }
+
+  private void reportCounter(String name, Counter counter) throws IOException {
+    statsD.send(prefix(name, "count"), format(counter.getCount()));
+  }
+
+  private void reportGauge(String name, Gauge gauge) throws IOException {
+    final String value = format(gauge.getValue());
+    if (value == null) {
+      LOGGER.warn("Unable to report gauge '{}' of unsupported type '{}'.",
+        name, gauge.getValue().getClass());
+    } else {
+      statsD.send(prefix(name), value);
+    }
+  }
+
+  private String format(Object o) {
+    if (o instanceof Float) {
+      return format(((Float) o).doubleValue());
+    } else if (o instanceof Double) {
+      return format(((Double) o).doubleValue());
+    } else if (o instanceof Byte) {
+      return format(((Byte) o).longValue());
+    } else if (o instanceof Short) {
+      return format(((Short) o).longValue());
+    } else if (o instanceof Integer) {
+      return format(((Integer) o).longValue());
+    } else if (o instanceof Long) {
+      return format(((Long) o).longValue());
+    }
+    return null;
+  }
+
+  private String prefix(String... components) {
+    return MetricRegistry.name(prefix, components);
+  }
+
+  private String format(long n) {
+    return Long.toString(n);
+  }
+
+  private String format(double v) {
+    return String.format(Locale.US, "%2.2f", v);
+  }
+}

--- a/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/DatagramSocketFactoryTest.java
+++ b/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/DatagramSocketFactoryTest.java
@@ -1,0 +1,25 @@
+package com.bealetech.metrics.reporting;
+
+import org.junit.Test;
+
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+
+import static org.junit.Assert.assertNotNull;
+
+public class DatagramSocketFactoryTest {
+  @Test
+  public void createDatagramSocket() throws SocketException {
+    DatagramSocket socket = new DatagramSocketFactory().createSocket();
+    assertNotNull(socket);
+  }
+
+  @Test
+  public void createDatagramPacket() throws SocketException {
+    InetSocketAddress address = new InetSocketAddress("example.com", 9876);
+    DatagramPacket packet = new DatagramSocketFactory().createPacket("yellow dellow".getBytes(), "yellow dellow".length(), address);
+    assertNotNull(packet);
+  }
+}

--- a/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/StatsDReporterTest.java
+++ b/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/StatsDReporterTest.java
@@ -1,0 +1,302 @@
+package com.bealetech.metrics.reporting;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricFilter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Snapshot;
+import com.codahale.metrics.Timer;
+import org.junit.Test;
+import org.mockito.InOrder;
+
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class StatsDReporterTest {
+  private final StatsD statsD = mock(StatsD.class);
+  private final MetricRegistry registry = mock(MetricRegistry.class);
+  private final StatsDReporter reporter = StatsDReporter.forRegistry(registry)
+    .prefixedWith("prefix")
+    .convertRatesTo(TimeUnit.SECONDS)
+    .convertDurationsTo(TimeUnit.MILLISECONDS)
+    .filter(MetricFilter.ALL)
+    .build(statsD);
+
+  @Test
+  public void doesNotReportStringGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge("value")),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD, never()).send("prefix.gauge", "value");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsByteGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge((byte) 1)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsShortGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge((short) 1)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsIntegerGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge(1)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsLongGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge(1L)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsFloatGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge(1.1f)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1.10");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsDoubleGaugeValues() throws Exception {
+    reporter.report(map("gauge", gauge(1.1)),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.gauge", "1.10");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsCounters() throws Exception {
+    final Counter counter = mock(Counter.class);
+    when(counter.getCount()).thenReturn(100L);
+
+    reporter.report(this.<Gauge>map(),
+      this.<Counter>map("counter", counter),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.counter.count", "100");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsHistograms() throws Exception {
+    final Histogram histogram = mock(Histogram.class);
+    when(histogram.getCount()).thenReturn(1L);
+
+    final Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.getMax()).thenReturn(2L);
+    when(snapshot.getMean()).thenReturn(3.0);
+    when(snapshot.getMin()).thenReturn(4L);
+    when(snapshot.getStdDev()).thenReturn(5.0);
+    when(snapshot.getMedian()).thenReturn(6.0);
+    when(snapshot.get75thPercentile()).thenReturn(7.0);
+    when(snapshot.get95thPercentile()).thenReturn(8.0);
+    when(snapshot.get98thPercentile()).thenReturn(9.0);
+    when(snapshot.get99thPercentile()).thenReturn(10.0);
+    when(snapshot.get999thPercentile()).thenReturn(11.0);
+
+    when(histogram.getSnapshot()).thenReturn(snapshot);
+
+    reporter.report(this.<Gauge>map(),
+      this.<Counter>map(),
+      this.<Histogram>map("histogram", histogram),
+      this.<Meter>map(),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.histogram.count", "1");
+    inOrder.verify(statsD).send("prefix.histogram.max", "2");
+    inOrder.verify(statsD).send("prefix.histogram.mean", "3.00");
+    inOrder.verify(statsD).send("prefix.histogram.min", "4");
+    inOrder.verify(statsD).send("prefix.histogram.stddev", "5.00");
+    inOrder.verify(statsD).send("prefix.histogram.p50", "6.00");
+    inOrder.verify(statsD).send("prefix.histogram.p75", "7.00");
+    inOrder.verify(statsD).send("prefix.histogram.p95", "8.00");
+    inOrder.verify(statsD).send("prefix.histogram.p98", "9.00");
+    inOrder.verify(statsD).send("prefix.histogram.p99", "10.00");
+    inOrder.verify(statsD).send("prefix.histogram.p999", "11.00");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsMeters() throws Exception {
+    final Meter meter = mock(Meter.class);
+    when(meter.getCount()).thenReturn(1L);
+    when(meter.getOneMinuteRate()).thenReturn(2.0);
+    when(meter.getFiveMinuteRate()).thenReturn(3.0);
+    when(meter.getFifteenMinuteRate()).thenReturn(4.0);
+    when(meter.getMeanRate()).thenReturn(5.0);
+
+    reporter.report(this.<Gauge>map(),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map("meter", meter),
+      this.<Timer>map());
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.meter.count", "1");
+    inOrder.verify(statsD).send("prefix.meter.m1_rate", "2.00");
+    inOrder.verify(statsD).send("prefix.meter.m5_rate", "3.00");
+    inOrder.verify(statsD).send("prefix.meter.m15_rate", "4.00");
+    inOrder.verify(statsD).send("prefix.meter.mean_rate", "5.00");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  @Test
+  public void reportsTimers() throws Exception {
+    final Timer timer = mock(Timer.class);
+    when(timer.getCount()).thenReturn(1L);
+    when(timer.getMeanRate()).thenReturn(2.0);
+    when(timer.getOneMinuteRate()).thenReturn(3.0);
+    when(timer.getFiveMinuteRate()).thenReturn(4.0);
+    when(timer.getFifteenMinuteRate()).thenReturn(5.0);
+
+    final Snapshot snapshot = mock(Snapshot.class);
+    when(snapshot.getMax()).thenReturn(TimeUnit.MILLISECONDS.toNanos(100));
+    when(snapshot.getMean()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(200));
+    when(snapshot.getMin()).thenReturn(TimeUnit.MILLISECONDS.toNanos(300));
+    when(snapshot.getStdDev()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(400));
+    when(snapshot.getMedian()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(500));
+    when(snapshot.get75thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(600));
+    when(snapshot.get95thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(700));
+    when(snapshot.get98thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(800));
+    when(snapshot.get99thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS.toNanos(900));
+    when(snapshot.get999thPercentile()).thenReturn((double) TimeUnit.MILLISECONDS
+      .toNanos(1000));
+
+    when(timer.getSnapshot()).thenReturn(snapshot);
+
+    reporter.report(this.<Gauge>map(),
+      this.<Counter>map(),
+      this.<Histogram>map(),
+      this.<Meter>map(),
+      map("timer", timer));
+
+    final InOrder inOrder = inOrder(statsD);
+    inOrder.verify(statsD).connect();
+    inOrder.verify(statsD).send("prefix.timer.max", "100.00");
+    inOrder.verify(statsD).send("prefix.timer.mean", "200.00");
+    inOrder.verify(statsD).send("prefix.timer.min", "300.00");
+    inOrder.verify(statsD).send("prefix.timer.stddev", "400.00");
+    inOrder.verify(statsD).send("prefix.timer.p50", "500.00");
+    inOrder.verify(statsD).send("prefix.timer.p75", "600.00");
+    inOrder.verify(statsD).send("prefix.timer.p95", "700.00");
+    inOrder.verify(statsD).send("prefix.timer.p98", "800.00");
+    inOrder.verify(statsD).send("prefix.timer.p99", "900.00");
+    inOrder.verify(statsD).send("prefix.timer.p999", "1000.00");
+    inOrder.verify(statsD).send("prefix.timer.count", "1");
+    inOrder.verify(statsD).send("prefix.timer.m1_rate", "3.00");
+    inOrder.verify(statsD).send("prefix.timer.m5_rate", "4.00");
+    inOrder.verify(statsD).send("prefix.timer.m15_rate", "5.00");
+    inOrder.verify(statsD).send("prefix.timer.mean_rate", "2.00");
+    inOrder.verify(statsD).close();
+
+    verifyNoMoreInteractions(statsD);
+  }
+
+  private <T> SortedMap<String, T> map() {
+    return new TreeMap<String, T>();
+  }
+
+  private <T> SortedMap<String, T> map(String name, T metric) {
+    final TreeMap<String, T> map = new TreeMap<String, T>();
+    map.put(name, metric);
+    return map;
+  }
+
+  private <T> Gauge gauge(T value) {
+    final Gauge gauge = mock(Gauge.class);
+    when(gauge.getValue()).thenReturn(value);
+    return gauge;
+  }
+}

--- a/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/StatsDTest.java
+++ b/metrics3-statsd/src/test/java/com/bealetech/metrics/reporting/StatsDTest.java
@@ -1,0 +1,104 @@
+package com.bealetech.metrics.reporting;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+
+import static org.fest.assertions.api.Assertions.assertThat;
+import static org.fest.assertions.api.Fail.failBecauseExceptionWasNotThrown;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StatsDTest {
+  private final DatagramSocketFactory socketFactory = mock(DatagramSocketFactory.class);
+  private final InetSocketAddress address = new InetSocketAddress("example.com", 1234);
+  private final StatsD statsD = new StatsD(address, socketFactory);
+
+  private final DatagramSocket socket = mock(DatagramSocket.class);
+
+  private final ArgumentCaptor<byte[]> bytesCaptor = ArgumentCaptor.forClass(byte[].class);
+  private final ArgumentCaptor<InetSocketAddress> addressCaptor = ArgumentCaptor.forClass(InetSocketAddress.class);
+
+  @Before
+  public void setUp() throws Exception {
+    when(socketFactory.createSocket()).thenReturn(socket);
+
+    when(socketFactory.createPacket(bytesCaptor.capture(), anyInt(), addressCaptor.capture()))
+      .thenCallRealMethod();
+  }
+
+  @Test
+  public void connectsToGraphite() throws Exception {
+    statsD.connect();
+
+    verify(socketFactory).createSocket();
+  }
+
+  @Test
+  public void measuresFailures() throws Exception {
+    assertThat(statsD.getFailures())
+      .isZero();
+  }
+
+  @Test
+  public void disconnectsFromGraphite() throws Exception {
+    statsD.connect();
+    statsD.close();
+
+    verify(socket).close();
+  }
+
+  @Test
+  public void doesNotAllowDoubleConnections() throws Exception {
+    statsD.connect();
+    try {
+      statsD.connect();
+      failBecauseExceptionWasNotThrown(IllegalStateException.class);
+    } catch (IllegalStateException e) {
+      assertThat(e.getMessage())
+        .isEqualTo("Already connected");
+    }
+  }
+
+  @Test
+  public void writesValuesToGraphite() throws Exception {
+    statsD.connect();
+    statsD.send("name", "value");
+
+    assertThat(new String(bytesCaptor.getValue()))
+      .isEqualTo("name:value|g");
+  }
+
+  @Test
+  public void sanitizesNames() throws Exception {
+    statsD.connect();
+    statsD.send("name woo", "value");
+
+    assertThat(new String(bytesCaptor.getValue()))
+      .isEqualTo("name-woo:value|g");
+  }
+
+  @Test
+  public void sanitizesValues() throws Exception {
+    statsD.connect();
+    statsD.send("name", "value woo");
+
+    assertThat(new String(bytesCaptor.getValue()))
+      .isEqualTo("name:value-woo|g");
+  }
+
+  @Test
+  public void address() throws IOException {
+    statsD.connect();
+    statsD.send("name", "value");
+
+    assertThat(addressCaptor.getValue())
+      .isEqualTo(address);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,2 @@
 include 'metrics2-statsd'
+include 'metrics3-statsd'


### PR DESCRIPTION
Here is a cleaner upgrade to the Metrics 3 interfaces.
- Use new ScheduledReporter base class
- Removed VM metrics for now. Metrics 3 dropped some Java 6 support. I should be fairly straightforward to add back in shortly.
