### PR TITLE
Specify UTF-8 as the explicit charset for OutputStreamWriter in the version 2 library

### DIFF
--- a/metrics2-statsd/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
+++ b/metrics2-statsd/src/main/java/com/bealetech/metrics/reporting/StatsdReporter.java
@@ -37,6 +37,7 @@ import java.util.concurrent.TimeUnit;
 
 public class StatsdReporter extends AbstractPollingReporter implements MetricProcessor<Long> {
     private static final Logger LOG = LoggerFactory.getLogger(StatsdReporter.class);
+    private static final Charset UTF_8 = Charset.forName("UTF-8");
 
     protected final String prefix;
     protected final MetricPredicate predicate;
@@ -115,7 +116,7 @@ public class StatsdReporter extends AbstractPollingReporter implements MetricPro
         try {
             socket = this.socketProvider.get();
             outputData.reset();
-            writer = new BufferedWriter(new OutputStreamWriter(this.outputData, Charset.forName("UTF-8")));
+            writer = new BufferedWriter(new OutputStreamWriter(this.outputData, UTF_8));
             serializer = new StatsdSerializer(prefix, writer);
 
             final long epoch = clock.time() / 1000;


### PR DESCRIPTION
This silences a FindBugs warning and matches the output format we use in the version 3 library.
