### PR TITLE
Fix metric names for timers, meters, and histograms. Add ".samples" to reads from count()

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = '4.0.0'
+  version = '4.1.0-SNAPSHOT'
 }
 
 buildscript {

--- a/metrics2-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
+++ b/metrics2-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
@@ -134,7 +134,7 @@ public class StatsDReporter extends AbstractPollingReporter implements MetricPro
   @Override
   public void processMeter(MetricName name, Metered meter, Long epoch) {
     final String sanitizedName = sanitizeName(name);
-    sendToStatsD(sanitizedName, formatNumber(meter.count()));
+    sendToStatsD(sanitizedName + ".samples", formatNumber(meter.count()));
     sendToStatsD(sanitizedName + ".meanRate", formatNumber(meter.meanRate()));
     sendToStatsD(sanitizedName + ".1MinuteRate", formatNumber(meter.oneMinuteRate()));
     sendToStatsD(sanitizedName + ".5MinuteRate", formatNumber(meter.fiveMinuteRate()));

--- a/metrics2-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
+++ b/metrics2-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
@@ -104,7 +104,7 @@ public class StatsDReporterTest {
   }
 
   public void verifyTimer() {
-    verifySend("1");
+    verifySend("samples", "1");
     verifySend("meanRate", "2.00");
     verifySend("1MinuteRate", "1.00");
     verifySend("5MinuteRate", "5.00");
@@ -122,7 +122,7 @@ public class StatsDReporterTest {
   }
 
   public void verifyMeter() {
-    verifySend("1");
+    verifySend("samples", "1");
     verifySend("meanRate", "2.00");
     verifySend("1MinuteRate", "1.00");
     verifySend("5MinuteRate", "5.00");

--- a/metrics3-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
+++ b/metrics3-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
@@ -219,7 +219,7 @@ public class StatsDReporter extends ScheduledReporter {
   }
 
   private void reportMetered(final String name, final Metered meter) {
-    statsD.send(prefix(name), formatNumber(meter.getCount()));
+    statsD.send(prefix(name, "samples"), formatNumber(meter.getCount()));
     statsD.send(prefix(name, "m1_rate"), formatNumber(convertRate(meter.getOneMinuteRate())));
     statsD.send(prefix(name, "m5_rate"), formatNumber(convertRate(meter.getFiveMinuteRate())));
     statsD.send(prefix(name, "m15_rate"), formatNumber(convertRate(meter.getFifteenMinuteRate())));
@@ -228,7 +228,7 @@ public class StatsDReporter extends ScheduledReporter {
 
   private void reportHistogram(final String name, final Histogram histogram) {
     final Snapshot snapshot = histogram.getSnapshot();
-    statsD.send(prefix(name), formatNumber(histogram.getCount()));
+    statsD.send(prefix(name, "samples"), formatNumber(histogram.getCount()));
     statsD.send(prefix(name, "max"), formatNumber(snapshot.getMax()));
     statsD.send(prefix(name, "mean"), formatNumber(snapshot.getMean()));
     statsD.send(prefix(name, "min"), formatNumber(snapshot.getMin()));

--- a/metrics3-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
+++ b/metrics3-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
@@ -165,7 +165,7 @@ public class StatsDReporterTest {
     final InOrder inOrder = inOrder(statsD);
 
     inOrder.verify(statsD).connect();
-    verify(statsD).send("prefix.histogram", "1");
+    verify(statsD).send("prefix.histogram.samples", "1");
     verify(statsD).send("prefix.histogram.max", "2");
     verify(statsD).send("prefix.histogram.mean", "3.00");
     verify(statsD).send("prefix.histogram.min", "4");
@@ -194,7 +194,7 @@ public class StatsDReporterTest {
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    verify(statsD).send("prefix.meter", "1");
+    verify(statsD).send("prefix.meter.samples", "1");
     verify(statsD).send("prefix.meter.m1_rate", "2.00");
     verify(statsD).send("prefix.meter.m5_rate", "3.00");
     verify(statsD).send("prefix.meter.m15_rate", "4.00");
@@ -242,7 +242,7 @@ public class StatsDReporterTest {
     verify(statsD).send("prefix.timer.p98", "800.00");
     verify(statsD).send("prefix.timer.p99", "900.00");
     verify(statsD).send("prefix.timer.p999", "1000.00");
-    verify(statsD).send("prefix.timer", "1");
+    verify(statsD).send("prefix.timer.samples", "1");
     verify(statsD).send("prefix.timer.m1_rate", "3.00");
     verify(statsD).send("prefix.timer.m5_rate", "4.00");
     verify(statsD).send("prefix.timer.m15_rate", "5.00");


### PR DESCRIPTION
Graphite-Web doesn't like metrics that are named with the same name as a subfolder. See graphite-project/graphite-web issue #193.
