### PR TITLE
Implemented suffixing possibility for metrics name

### DIFF
--- a/metrics3-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
+++ b/metrics3-statsd/src/main/java/com/readytalk/metrics/StatsDReporter.java
@@ -49,16 +49,19 @@ public class StatsDReporter extends ScheduledReporter {
 
   private final StatsD statsD;
   private final String prefix;
+  private final String suffix;
 
   private StatsDReporter(final MetricRegistry registry,
                          final StatsD statsD,
                          final String prefix,
+                         final String suffix,
                          final TimeUnit rateUnit,
                          final TimeUnit durationUnit,
                          final MetricFilter filter) {
     super(registry, "statsd-reporter", filter, rateUnit, durationUnit);
     this.statsD = statsD;
     this.prefix = prefix;
+    this.suffix = suffix;
   }
 
   /**
@@ -80,6 +83,7 @@ public class StatsDReporter extends ScheduledReporter {
   public static final class Builder {
     private final MetricRegistry registry;
     private String prefix;
+    private String suffix;
     private TimeUnit rateUnit;
     private TimeUnit durationUnit;
     private MetricFilter filter;
@@ -100,6 +104,17 @@ public class StatsDReporter extends ScheduledReporter {
      */
     public Builder prefixedWith(@Nullable final String _prefix) {
       this.prefix = _prefix;
+      return this;
+    }
+
+    /**
+     * Prefix all metric names with the given string.
+     *
+     * @param _suffix the prefix for all metric names
+     * @return {@code this}
+     */
+    public Builder suffixedWith(@Nullable final String _suffix) {
+      this.suffix = _suffix;
       return this;
     }
 
@@ -155,7 +170,7 @@ public class StatsDReporter extends ScheduledReporter {
      * @return a {@link StatsDReporter}
      */
     public StatsDReporter build(final StatsD statsD) {
-      return new StatsDReporter(registry, statsD, prefix, rateUnit, durationUnit, filter);
+      return new StatsDReporter(registry, statsD, prefix, suffix, rateUnit, durationUnit, filter);
     }
   }
 
@@ -203,53 +218,58 @@ public class StatsDReporter extends ScheduledReporter {
 
   private void reportTimer(final String name, final Timer timer) {
     final Snapshot snapshot = timer.getSnapshot();
+    String suffixedName = suffix(name);
 
-    statsD.send(prefix(name, "max"), formatNumber(convertDuration(snapshot.getMax())));
-    statsD.send(prefix(name, "mean"), formatNumber(convertDuration(snapshot.getMean())));
-    statsD.send(prefix(name, "min"), formatNumber(convertDuration(snapshot.getMin())));
-    statsD.send(prefix(name, "stddev"), formatNumber(convertDuration(snapshot.getStdDev())));
-    statsD.send(prefix(name, "p50"), formatNumber(convertDuration(snapshot.getMedian())));
-    statsD.send(prefix(name, "p75"), formatNumber(convertDuration(snapshot.get75thPercentile())));
-    statsD.send(prefix(name, "p95"), formatNumber(convertDuration(snapshot.get95thPercentile())));
-    statsD.send(prefix(name, "p98"), formatNumber(convertDuration(snapshot.get98thPercentile())));
-    statsD.send(prefix(name, "p99"), formatNumber(convertDuration(snapshot.get99thPercentile())));
-    statsD.send(prefix(name, "p999"), formatNumber(convertDuration(snapshot.get999thPercentile())));
+    statsD.send(prefix(suffixedName, "max"), formatNumber(convertDuration(snapshot.getMax())));
+    statsD.send(prefix(suffixedName, "mean"), formatNumber(convertDuration(snapshot.getMean())));
+    statsD.send(prefix(suffixedName, "min"), formatNumber(convertDuration(snapshot.getMin())));
+    statsD.send(prefix(suffixedName, "stddev"), formatNumber(convertDuration(snapshot.getStdDev())));
+    statsD.send(prefix(suffixedName, "p50"), formatNumber(convertDuration(snapshot.getMedian())));
+    statsD.send(prefix(suffixedName, "p75"), formatNumber(convertDuration(snapshot.get75thPercentile())));
+    statsD.send(prefix(suffixedName, "p95"), formatNumber(convertDuration(snapshot.get95thPercentile())));
+    statsD.send(prefix(suffixedName, "p98"), formatNumber(convertDuration(snapshot.get98thPercentile())));
+    statsD.send(prefix(suffixedName, "p99"), formatNumber(convertDuration(snapshot.get99thPercentile())));
+    statsD.send(prefix(suffixedName, "p999"), formatNumber(convertDuration(snapshot.get999thPercentile())));
 
     reportMetered(name, timer);
   }
 
   private void reportMetered(final String name, final Metered meter) {
-    statsD.send(prefix(name, "samples"), formatNumber(meter.getCount()));
-    statsD.send(prefix(name, "m1_rate"), formatNumber(convertRate(meter.getOneMinuteRate())));
-    statsD.send(prefix(name, "m5_rate"), formatNumber(convertRate(meter.getFiveMinuteRate())));
-    statsD.send(prefix(name, "m15_rate"), formatNumber(convertRate(meter.getFifteenMinuteRate())));
-    statsD.send(prefix(name, "mean_rate"), formatNumber(convertRate(meter.getMeanRate())));
+    String suffixedName = suffix(name);
+
+    statsD.send(prefix(suffixedName, "samples"), formatNumber(meter.getCount()));
+    statsD.send(prefix(suffixedName, "m1_rate"), formatNumber(convertRate(meter.getOneMinuteRate())));
+    statsD.send(prefix(suffixedName, "m5_rate"), formatNumber(convertRate(meter.getFiveMinuteRate())));
+    statsD.send(prefix(suffixedName, "m15_rate"), formatNumber(convertRate(meter.getFifteenMinuteRate())));
+    statsD.send(prefix(suffixedName, "mean_rate"), formatNumber(convertRate(meter.getMeanRate())));
   }
 
   private void reportHistogram(final String name, final Histogram histogram) {
     final Snapshot snapshot = histogram.getSnapshot();
-    statsD.send(prefix(name, "samples"), formatNumber(histogram.getCount()));
-    statsD.send(prefix(name, "max"), formatNumber(snapshot.getMax()));
-    statsD.send(prefix(name, "mean"), formatNumber(snapshot.getMean()));
-    statsD.send(prefix(name, "min"), formatNumber(snapshot.getMin()));
-    statsD.send(prefix(name, "stddev"), formatNumber(snapshot.getStdDev()));
-    statsD.send(prefix(name, "p50"), formatNumber(snapshot.getMedian()));
-    statsD.send(prefix(name, "p75"), formatNumber(snapshot.get75thPercentile()));
-    statsD.send(prefix(name, "p95"), formatNumber(snapshot.get95thPercentile()));
-    statsD.send(prefix(name, "p98"), formatNumber(snapshot.get98thPercentile()));
-    statsD.send(prefix(name, "p99"), formatNumber(snapshot.get99thPercentile()));
-    statsD.send(prefix(name, "p999"), formatNumber(snapshot.get999thPercentile()));
+    String suffixedName = suffix(name);
+
+    statsD.send(prefix(suffixedName, "samples"), formatNumber(histogram.getCount()));
+    statsD.send(prefix(suffixedName, "max"), formatNumber(snapshot.getMax()));
+    statsD.send(prefix(suffixedName, "mean"), formatNumber(snapshot.getMean()));
+    statsD.send(prefix(suffixedName, "min"), formatNumber(snapshot.getMin()));
+    statsD.send(prefix(suffixedName, "stddev"), formatNumber(snapshot.getStdDev()));
+    statsD.send(prefix(suffixedName, "p50"), formatNumber(snapshot.getMedian()));
+    statsD.send(prefix(suffixedName, "p75"), formatNumber(snapshot.get75thPercentile()));
+    statsD.send(prefix(suffixedName, "p95"), formatNumber(snapshot.get95thPercentile()));
+    statsD.send(prefix(suffixedName, "p98"), formatNumber(snapshot.get98thPercentile()));
+    statsD.send(prefix(suffixedName, "p99"), formatNumber(snapshot.get99thPercentile()));
+    statsD.send(prefix(suffixedName, "p999"), formatNumber(snapshot.get999thPercentile()));
   }
 
   private void reportCounter(final String name, final Counter counter) {
-    statsD.send(prefix(name), formatNumber(counter.getCount()));
+    statsD.send(prefix(suffix(name)), formatNumber(counter.getCount()));
   }
 
   @SuppressWarnings("rawtypes") //Metrics 3.0 passes us the raw Gauge type
   private void reportGauge(final String name, final Gauge gauge) {
     final String value = format(gauge.getValue());
     if (value != null) {
-      statsD.send(prefix(name), value);
+      statsD.send(prefix(suffix(name)), value);
     }
   }
 
@@ -277,6 +297,13 @@ public class StatsDReporter extends ScheduledReporter {
 
   private String prefix(final String... components) {
     return MetricRegistry.name(prefix, components);
+  }
+
+  private String suffix(String name) {
+    if (suffix == null || suffix.isEmpty() || !name.contains("%s")) {
+      return name;
+    }
+    return String.format(name, suffix);
   }
 
   private String formatNumber(final BigInteger n) {

--- a/metrics3-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
+++ b/metrics3-statsd/src/test/java/com/readytalk/metrics/StatsDReporterTest.java
@@ -41,6 +41,7 @@ public class StatsDReporterTest {
   private final MetricRegistry registry = mock(MetricRegistry.class);
   private final StatsDReporter reporter = StatsDReporter.forRegistry(registry)
       .prefixedWith("prefix")
+      .suffixedWith("suffix")
       .convertRatesTo(TimeUnit.SECONDS)
       .convertDurationsTo(TimeUnit.MILLISECONDS)
       .filter(MetricFilter.ALL)
@@ -51,78 +52,78 @@ public class StatsDReporterTest {
 
   @Test
   public void doesNotReportStringGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge("value")), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
-        this.<Timer>map());
+    reporter.report(map("%s.gauge", gauge("value")), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+            this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD, never()).send("prefix.gauge", "value");
+    inOrder.verify(statsD, never()).send("prefix.suffix.gauge", "value");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsByteGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge((byte) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge((byte) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsShortGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge((short) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge((short) 1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsIntegerGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge(1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge(1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsLongGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge(1L)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge(1L)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsFloatGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge(1.1f)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge(1.1f)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1.10");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1.10");
     inOrder.verify(statsD).close();
   }
 
   @Test
   public void reportsDoubleGaugeValues() throws Exception {
-    reporter.report(map("gauge", gauge(1.1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
+    reporter.report(map("%s.gauge", gauge(1.1)), this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.gauge", "1.10");
+    inOrder.verify(statsD).send("prefix.suffix.gauge", "1.10");
     inOrder.verify(statsD).close();
   }
 
@@ -131,12 +132,12 @@ public class StatsDReporterTest {
     final Counter counter = mock(Counter.class);
     when(counter.getCount()).thenReturn(100L);
 
-    reporter.report(emptyGaugeMap, this.<Counter>map("counter", counter), this.<Histogram>map(),
+    reporter.report(emptyGaugeMap, this.<Counter>map("%s.counter", counter), this.<Histogram>map(),
         this.<Meter>map(), this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    inOrder.verify(statsD).send("prefix.counter", "100");
+    inOrder.verify(statsD).send("prefix.suffix.counter", "100");
     inOrder.verify(statsD).close();
   }
 
@@ -159,23 +160,23 @@ public class StatsDReporterTest {
 
     when(histogram.getSnapshot()).thenReturn(snapshot);
 
-    reporter.report(emptyGaugeMap, this.<Counter>map(), this.<Histogram>map("histogram", histogram),
+    reporter.report(emptyGaugeMap, this.<Counter>map(), this.<Histogram>map("histogram.%s", histogram),
         this.<Meter>map(), this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
 
     inOrder.verify(statsD).connect();
-    verify(statsD).send("prefix.histogram.samples", "1");
-    verify(statsD).send("prefix.histogram.max", "2");
-    verify(statsD).send("prefix.histogram.mean", "3.00");
-    verify(statsD).send("prefix.histogram.min", "4");
-    verify(statsD).send("prefix.histogram.stddev", "5.00");
-    verify(statsD).send("prefix.histogram.p50", "6.00");
-    verify(statsD).send("prefix.histogram.p75", "7.00");
-    verify(statsD).send("prefix.histogram.p95", "8.00");
-    verify(statsD).send("prefix.histogram.p98", "9.00");
-    verify(statsD).send("prefix.histogram.p99", "10.00");
-    inOrder.verify(statsD).send("prefix.histogram.p999", "11.00");
+    verify(statsD).send("prefix.histogram.suffix.samples", "1");
+    verify(statsD).send("prefix.histogram.suffix.max", "2");
+    verify(statsD).send("prefix.histogram.suffix.mean", "3.00");
+    verify(statsD).send("prefix.histogram.suffix.min", "4");
+    verify(statsD).send("prefix.histogram.suffix.stddev", "5.00");
+    verify(statsD).send("prefix.histogram.suffix.p50", "6.00");
+    verify(statsD).send("prefix.histogram.suffix.p75", "7.00");
+    verify(statsD).send("prefix.histogram.suffix.p95", "8.00");
+    verify(statsD).send("prefix.histogram.suffix.p98", "9.00");
+    verify(statsD).send("prefix.histogram.suffix.p99", "10.00");
+    inOrder.verify(statsD).send("prefix.histogram.suffix.p999", "11.00");
 
     inOrder.verify(statsD).close();
   }
@@ -189,16 +190,16 @@ public class StatsDReporterTest {
     when(meter.getFifteenMinuteRate()).thenReturn(4.0);
     when(meter.getMeanRate()).thenReturn(5.0);
 
-    reporter.report(emptyGaugeMap, this.<Counter>map(), this.<Histogram>map(), this.<Meter>map("meter", meter),
+    reporter.report(emptyGaugeMap, this.<Counter>map(), this.<Histogram>map(), this.<Meter>map("meter.%s", meter),
         this.<Timer>map());
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    verify(statsD).send("prefix.meter.samples", "1");
-    verify(statsD).send("prefix.meter.m1_rate", "2.00");
-    verify(statsD).send("prefix.meter.m5_rate", "3.00");
-    verify(statsD).send("prefix.meter.m15_rate", "4.00");
-    inOrder.verify(statsD).send("prefix.meter.mean_rate", "5.00");
+    verify(statsD).send("prefix.meter.suffix.samples", "1");
+    verify(statsD).send("prefix.meter.suffix.m1_rate", "2.00");
+    verify(statsD).send("prefix.meter.suffix.m5_rate", "3.00");
+    verify(statsD).send("prefix.meter.suffix.m15_rate", "4.00");
+    inOrder.verify(statsD).send("prefix.meter.suffix.mean_rate", "5.00");
     inOrder.verify(statsD).close();
 
 
@@ -228,25 +229,25 @@ public class StatsDReporterTest {
     when(timer.getSnapshot()).thenReturn(snapshot);
 
     reporter.report(emptyGaugeMap, this.<Counter>map(), this.<Histogram>map(), this.<Meter>map(),
-        map("timer", timer));
+        map("timer.%s", timer));
 
     final InOrder inOrder = inOrder(statsD);
     inOrder.verify(statsD).connect();
-    verify(statsD).send("prefix.timer.max", "100.00");
-    verify(statsD).send("prefix.timer.mean", "200.00");
-    verify(statsD).send("prefix.timer.min", "300.00");
-    verify(statsD).send("prefix.timer.stddev", "400.00");
-    verify(statsD).send("prefix.timer.p50", "500.00");
-    verify(statsD).send("prefix.timer.p75", "600.00");
-    verify(statsD).send("prefix.timer.p95", "700.00");
-    verify(statsD).send("prefix.timer.p98", "800.00");
-    verify(statsD).send("prefix.timer.p99", "900.00");
-    verify(statsD).send("prefix.timer.p999", "1000.00");
-    verify(statsD).send("prefix.timer.samples", "1");
-    verify(statsD).send("prefix.timer.m1_rate", "3.00");
-    verify(statsD).send("prefix.timer.m5_rate", "4.00");
-    verify(statsD).send("prefix.timer.m15_rate", "5.00");
-    inOrder.verify(statsD).send("prefix.timer.mean_rate", "2.00");
+    verify(statsD).send("prefix.timer.suffix.max", "100.00");
+    verify(statsD).send("prefix.timer.suffix.mean", "200.00");
+    verify(statsD).send("prefix.timer.suffix.min", "300.00");
+    verify(statsD).send("prefix.timer.suffix.stddev", "400.00");
+    verify(statsD).send("prefix.timer.suffix.p50", "500.00");
+    verify(statsD).send("prefix.timer.suffix.p75", "600.00");
+    verify(statsD).send("prefix.timer.suffix.p95", "700.00");
+    verify(statsD).send("prefix.timer.suffix.p98", "800.00");
+    verify(statsD).send("prefix.timer.suffix.p99", "900.00");
+    verify(statsD).send("prefix.timer.suffix.p999", "1000.00");
+    verify(statsD).send("prefix.timer.suffix.samples", "1");
+    verify(statsD).send("prefix.timer.suffix.m1_rate", "3.00");
+    verify(statsD).send("prefix.timer.suffix.m5_rate", "4.00");
+    verify(statsD).send("prefix.timer.suffix.m15_rate", "5.00");
+    inOrder.verify(statsD).send("prefix.timer.suffix.mean_rate", "2.00");
     inOrder.verify(statsD).close();
   }
 


### PR DESCRIPTION
In our architecture, we run statsd on each server, and they all send to a central graphite server and it's pretty useful to have the possibility to suffix the metric name with current host name. 

This pull request  allows you to send metrics like "some.metric.name.with.suffix.%s" if you configure the suffix as "host1" it'll be replaced as "some.metric.name.with.suffix.host1".
