### PR TITLE
Fix javadoc formatting error

### DIFF
--- a/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
+++ b/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
@@ -67,7 +67,6 @@ public class StatsD implements Closeable {
 
   /**
    * Resolves the address hostname if present.
-   * <p/>
    * Creates a datagram socket through the factory.
    *
    * @throws IllegalStateException if the client is already connected


### PR DESCRIPTION
When running "./gradlew build":

:metrics-statsd-common:javadoc
metrics-statsd/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java:70: error: self-closing element not allowed
- <p/>
