### PR TITLE
Switch StatsD constructors from package-private to public

### DIFF
--- a/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
+++ b/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
@@ -50,7 +50,7 @@ public class StatsD implements Closeable {
    * @param host the hostname of the StatsD server.
    * @param port the port of the StatsD server. This is typically 8125.
    */
-  StatsD(final String host, final int port) {
+  public StatsD(final String host, final int port) {
     this(new InetSocketAddress(host, port), new DatagramSocketFactory());
   }
 
@@ -60,7 +60,7 @@ public class StatsD implements Closeable {
    * @param address       the address of the Carbon server
    * @param socketFactory the socket factory
    */
-  StatsD(final InetSocketAddress address, final DatagramSocketFactory socketFactory) {
+  public StatsD(final InetSocketAddress address, final DatagramSocketFactory socketFactory) {
     this.address = address;
     this.socketFactory = socketFactory;
   }


### PR DESCRIPTION
Both versions of StatsDReporter accept a StatsD object during
construction, but the StatsD object itself cannot currently be created
outside of com.readytalk.metrics.

This is especially a problem in metrics2-statsd's StatsDReporter,
where the longer constructors _require_ passing a StatsD object.
