### PR TITLE
Upgraded metrics-core to 3.1.0

### DIFF
--- a/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
+++ b/metrics-statsd-common/src/main/java/com/readytalk/metrics/StatsD.java
@@ -67,7 +67,7 @@ public class StatsD implements Closeable {
 
   /**
    * Resolves the address hostname if present.
-   * <p/>
+   *
    * Creates a datagram socket through the factory.
    *
    * @throws IllegalStateException if the client is already connected

--- a/metrics3-statsd/build.gradle
+++ b/metrics3-statsd/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':metrics-statsd-common')
   provided (
-    'com.codahale.metrics:metrics-core:3.0.0'
+    'io.dropwizard.metrics:metrics-core:3.1.0'
   )
 }
 


### PR DESCRIPTION
- Upgraded metrics-core to 3.1.0 (io.dropwizard.metrics:metrics-core:3.1.0).
- Fixed a javadoc error.

This patch addresses https://github.com/ReadyTalk/metrics-statsd/issues/16