### PR TITLE
Start v4.2.0 development

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=4.1.2-SNAPSHOT
+version=4.2.0-SNAPSHOT

--- a/metrics3-statsd/build.gradle
+++ b/metrics3-statsd/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':metrics-statsd-common')
   provided (
-    'com.codahale.metrics:metrics-core:3.0.0'
+    'io.dropwizard.metrics:metrics-core:3.1.3'
   )
 }
 


### PR DESCRIPTION
Upgrade metrics library to the newest release of the 3.1.x maintenence series.

This should resolve #16 and #29 - I modified #29 slightly to use the most updated artifact from the 3.1.x series which appears to be backwards compatible with our usage of the library.