### PR TITLE
Setup to publish to nexus and bump dropwizard version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,12 +85,26 @@ subprojects {
 
   publishing {
     publications {
-      mavenJava(MavenPublication) {
+      maven(MavenPublication) {
         from components.java
+
+        version System.env['BUILD_NUMBER'] ?: '1.0.0-SNAPSHOT'
 
         artifact sourceJar {
           classifier "sources"
         }
+      }
+    }
+
+    repositories {
+      maven {
+        credentials {
+          username System.env['USERNAME'] ?: ''
+          password System.env['PASSWORD'] ?: ''
+        }
+
+        name = 'ewe-nexus'
+        url = 'http://nexus.sb.karmalab.net/nexus/content/repositories/releases/'
       }
     }
   }

--- a/metrics3-statsd/build.gradle
+++ b/metrics3-statsd/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
   compile project(':metrics-statsd-common')
   provided (
-    'io.dropwizard.metrics:metrics-core:3.1.3'
+    'io.dropwizard.metrics:metrics-core:4.0.2'
   )
 }
 


### PR DESCRIPTION
This PR updates dropwizard to pick up changes that support java 9+ (dropwizard/metrics#1236).

Additionally, it's adding logic to publish to nexus.